### PR TITLE
feat(ci): close issues on promotion to main, not on merge to development

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,29 @@ jobs:
             echo "::error::No changeset found. Run 'npx changeset' to add one, or apply the 'skip-changelog' label to this PR."
             exit 1
           fi
+
+  no-premature-close:
+    # development is the default branch, so a stray "Closes #NN" here would
+    # auto-close the issue on merge, before the fix ever reaches main. Issues
+    # should only close via .github/workflows/close-promoted-issues.yml, once
+    # promoted to main — use "Refs #NN" in commits/PRs targeting development.
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.base_ref == 'development'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Forbid closing keywords on PRs into development
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          git fetch origin "${{ github.event.pull_request.base.ref }}" --depth=1
+          COMMIT_MSGS=$(git log "origin/${{ github.event.pull_request.base.ref }}...HEAD" --format=%B)
+          MATCHES=$(printf '%s\n%s' "$PR_BODY" "$COMMIT_MSGS" | grep -iEo '\b(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)[[:space:]]+#[0-9]+' || true)
+          if [ -n "$MATCHES" ]; then
+            echo "::error::Found a closing keyword targeting development: $(echo "$MATCHES" | tr '\n' ' '). Issues should stay open until promoted to main — use 'Refs #NN' instead of 'Closes/Fixes/Resolves #NN'."
+            exit 1
+          fi

--- a/.github/workflows/close-promoted-issues.yml
+++ b/.github/workflows/close-promoted-issues.yml
@@ -1,0 +1,53 @@
+name: Close issues promoted to main
+
+# development is the default branch, so GitHub's native "Closes #NN" only
+# auto-closes on merges there. Issues should stay open until the fix is
+# actually live on main (mainnet-ready), so this workflow re-implements
+# closing keyword handling anchored to main instead.
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  close-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Collect issue references
+        id: refs
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          COMMIT_MSGS=$(git log "$BASE_SHA..$MERGE_SHA" --format=%B 2>/dev/null || true)
+          ISSUES=$(printf '%s\n%s' "$PR_BODY" "$COMMIT_MSGS" \
+            | grep -iEo '\b(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved|ref|refs)[[:space:]]+#[0-9]+' \
+            | grep -oE '[0-9]+' \
+            | sort -un)
+          {
+            echo "issues<<ISSUES_EOF"
+            echo "$ISSUES"
+            echo "ISSUES_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Close referenced issues
+        if: steps.refs.outputs.issues != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUES: ${{ steps.refs.outputs.issues }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          for n in $ISSUES; do
+            gh issue close "$n" --repo "${{ github.repository }}" \
+              --comment "Shipped to \`main\` in $PR_URL." || true
+          done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,17 @@ Branch from `development` — it's the active branch and the target for all pull
 
 5. Open a pull request against `development`.
 
+## Referencing issues
+
+`development` is the default branch, so GitHub auto-closes an issue the moment a commit or PR
+merges there if it uses a closing keyword (`Closes`/`Fixes`/`Resolves #NN`) — but a change isn't
+really done until it's promoted through `staging` and lands on `main`. So:
+
+- In commits and PRs targeting `development`, reference issues with `Refs #NN` (a CI check fails
+  the PR if it finds `Closes`/`Fixes`/`Resolves` instead).
+- Issues close automatically once the fix reaches `main` — a workflow scans the promoting PR for
+  `Refs #NN` (and the standard closing keywords) and closes whatever it finds.
+
 ## Filing issues
 
 This repository's issues are tracked centrally in the


### PR DESCRIPTION
## Summary

Follow-up to switching the repo's default branch to `development` (done as part of this PR). GitHub's closing keywords ("Closes #NN") only auto-close on merges to the *default* branch — but issues here shouldn't be considered done until the fix is actually promoted through `staging` and lands on `main` as a mainnet-ready release. So:

- **`no-premature-close`** (new CI job): fails a PR into `development` if its body or commits contain `Closes`/`Fixes`/`Resolves #NN` — the intended keyword there is `Refs #NN`, which just links without closing.
- **`close-promoted-issues.yml`** (new workflow): fires when a PR merges into `main`, scans its body and commit range for `Refs`/`Closes`/`Fixes`/`Resolves #NN`, and closes whatever it finds — reimplementing "auto-close" anchored to `main` regardless of which branch is default.
- **CONTRIBUTING.md**: documents the `Refs #NN` convention and the promotion-based closing behavior.

## Test plan
- [x] Dry-ran both grep pipelines locally against representative PR bodies/commit logs (Closes → correctly flagged, Refs → correctly passes, "bugfix" prose → no false positive, multi-issue collection → correctly deduped/sorted)
- [x] Validated both workflow YAML files parse
- [x] `npm run lint` / `npm run typecheck` pass (no packages/examples files touched)
- [ ] First real run of `close-promoted-issues.yml` on an actual main-promotion PR (can't fully exercise the `pull_request: closed` trigger outside of GitHub)

Refs #13