### PR TITLE
Release @lerna-labs/hydra-sdk 2.0.0

### DIFF
--- a/.changeset/resilient-deposits-and-roundtrip.md
+++ b/.changeset/resilient-deposits-and-roundtrip.md
@@ -1,0 +1,5 @@
+---
+"@lerna-labs/hydra-sdk": minor
+---
+
+Add rollback-resilient deposits via `Wrangler.depositResilient`, which automatically re-drafts a deposit when a submit fails on a transient stale-input error. Harden the preprod close and fanout path so the full open to fanout round-trip is proven end to end.


### PR DESCRIPTION
Adds a changeset to release the three core features that have been on development since the last publish (2026-06-23), graduating `@lerna-labs/hydra-sdk` from `2.0.0-beta.1` to a stable **2.0.0** on the `latest` dist-tag:

- rollback-resilient deposits (`Wrangler.depositResilient`)
- automatic deposit re-draft on transient stale-input submit errors
- the proven preprod close and fanout round-trip

Flowing this through staging publishes a `2.0.0-rc-<ts>` preview under `rc` (the first live run of the OIDC publish), then main cuts `2.0.0` to `latest` with provenance. `@lerna-labs/hydra-proof` is unchanged and stays at `1.0.0-beta.1`.