### PR TITLE
fix(ci): correct rc snapshot version and OIDC publish

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,5 +9,8 @@
   "updateInternalDependencies": "patch",
   "ignore": [
     "@lerna-labs/hydra-orchestrator"
-  ]
+  ],
+  "snapshot": {
+    "useCalculatedVersion": true
+  }
 }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -116,10 +116,24 @@ jobs:
 
       - name: Publish release-candidate previews to npm
         if: steps.snap.outputs.has == 'true'
-        # changeset publish only publishes packages whose (snapshot) version is
-        # not already on npm, so unchanged packages are skipped automatically.
-        # --no-git-tag: snapshots are ephemeral, never tagged in git.
-        run: npx changeset publish --tag rc --no-git-tag
+        # Publish each package that actually got a snapshot bump (version now
+        # contains -rc-) with plain `npm publish`, which uses OIDC trusted
+        # publishing. `changeset publish` reads the setup-node placeholder token
+        # from the .npmrc and would try token auth instead. Snapshots are
+        # ephemeral, so no git tags are created.
+        run: |
+          for dir in packages/core packages/proof; do
+            ver=$(node -p "require('./$dir/package.json').version")
+            case "$ver" in
+              *-rc-*)
+                echo "Publishing $dir@$ver under rc"
+                npm publish -w "./$dir" --tag rc
+                ;;
+              *)
+                echo "Skipping $dir@$ver (no snapshot bump)"
+                ;;
+            esac
+          done
 
       - name: Discard snapshot bump
         if: steps.snap.outputs.has == 'true'


### PR DESCRIPTION
Fixes two issues found on the first live `rc` publish:

- **Snapshot version was `0.0.0-rc-...`** — restores `snapshot.useCalculatedVersion: true` in the changeset config so staging previews use the real version (`2.0.0-rc-<ts>`).
- **`rc` publish hit E404 (token auth)** — calling `changeset publish` directly picks up setup-node's placeholder `NODE_AUTH_TOKEN` and tries token auth. Switched the rc job to a plain per-package `npm publish`, which uses OIDC trusted publishing. (The `main` release path is unaffected: it publishes through `changesets/action`, which does OIDC correctly.)

Once merged and promoted to staging, the rc job re-runs and should publish `2.0.0-rc-<ts>` under the `rc` dist-tag via OIDC.