### PR TITLE
fix(ci): publish releases via plain npm publish (OIDC)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "docs:api": "typedoc",
     "changeset": "changeset",
     "changeset:version": "changeset version",
-    "changeset:publish": "npm run build && changeset publish",
+    "changeset:publish": "npm run build && node scripts/publish-packages.mjs",
     "changeset:snapshot": "changeset version --snapshot rc",
     "prepare": "husky"
   },

--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -1,0 +1,37 @@
+// Publish the changed public packages to npm with plain `npm publish`, which
+// uses OIDC trusted publishing (npm >= 11.5.1 on PATH). `changeset publish`
+// signs provenance but authenticates with a non-OIDC npm and gets E404, so we
+// drive npm directly. Emits a "New tag:" line per publish so changesets/action
+// creates the GitHub Release; the git tag is pushed here (a real release tag),
+// which is what backport-release.yml triggers on.
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+const packages = [
+  { dir: 'packages/core', name: '@lerna-labs/hydra-sdk' },
+  { dir: 'packages/proof', name: '@lerna-labs/hydra-proof' },
+];
+
+const onNpm = (name, version) => {
+  try {
+    execSync(`npm view ${name}@${version} version`, { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+for (const { dir, name } of packages) {
+  const { version } = JSON.parse(readFileSync(`${dir}/package.json`, 'utf8'));
+  if (onNpm(name, version)) {
+    console.log(`${name}@${version} already on npm; skipping`);
+    continue;
+  }
+  execSync(`npm publish -w ${name} --access public`, { stdio: 'inherit' });
+  const tag = `${name}@${version}`;
+  if (!execSync(`git tag -l "${tag}"`, { encoding: 'utf8' }).trim()) {
+    execSync(`git tag "${tag}"`, { stdio: 'inherit' });
+    execSync(`git push origin "${tag}"`, { stdio: 'inherit' });
+  }
+  console.log(`New tag: ${tag}`);
+}


### PR DESCRIPTION
main is bumped to 2.0.0 (version PR merged) but the publish failed: `changeset publish` signs provenance via OIDC but authenticates the registry PUT with a non-OIDC npm, returning E404. The `rc` job already works because it uses plain `npm publish`.

This points `changeset:publish` at a small script that publishes each changed package with plain `npm publish` (OIDC trusted publishing), pushes the `<pkg>@<version>` release tag, and emits `New tag:` so `changesets/action` creates the GitHub Release.

Merging re-runs the release job on main and publishes **2.0.0** to `latest`; the release tag then backports the fix (and the version) down to staging and development. Applied as a hotfix directly to main because main is mid-release; the backport propagates it.