### PR TITLE
fix(ci): publish releases in a direct step for OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,16 +64,25 @@ jobs:
 
       - run: npm ci
 
-      - name: Create release PR or publish to npm
+      - name: Open or update the Version Packages PR
         uses: changesets/action@v1
         with:
           version: npm run changeset:version
-          publish: npm run changeset:publish
           commit: "chore(release): version packages"
           title: "chore(release): version packages"
         env:
-          # No NODE_AUTH_TOKEN: npm publishes via OIDC trusted publishing.
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      # Publish as a direct job step, not through changesets/action. Its `publish`
+      # runs the command under node's bundled npm (10.x on node 22), which signs
+      # provenance but cannot authenticate OIDC trusted publishing and 404s. A
+      # direct step uses the npm@11 we installed above, which does OIDC. The
+      # script skips packages whose version is already on npm, so this is a no-op
+      # except right after a Version Packages PR merges.
+      - name: Publish released packages to npm
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: node scripts/publish-packages.mjs
 
   # Release candidate from staging. Publishes a Changesets snapshot
   # (X.Y.Z-rc-<timestamp>) of the changed packages under the `rc` dist-tag so


### PR DESCRIPTION
changesets/action runs its `publish` command under node 22's bundled npm 10.x, which signs provenance but can't authenticate OIDC and returns E404. This uses changesets/action only for the Version Packages PR, and publishes in a direct job step that uses the upgraded npm@11 (the same path the working `rc` job uses). Merging re-runs the release on main and publishes 2.0.0 to latest.